### PR TITLE
Attempt to fix bug resulting in intersecting parts (server crashes)

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3807,6 +3807,12 @@ bool MergeTreeData::renameTempPartAndReplaceImpl(
 
     PartHierarchy hierarchy = getPartHierarchy(part->info, DataPartState::Active, lock);
 
+    if (!hierarchy.covering_parts.empty())
+    {
+        LOG_WARNING(log, "Tried to add obsolete part {} covered by {}", part->name, hierarchy.covering_parts.back());
+        return false;
+    }
+
     if (!hierarchy.intersected_parts.empty())
     {
         // Drop part|partition operation inside some transactions sees some stale snapshot from the time when transactions has been started.


### PR DESCRIPTION
I saw a server crash with error `Part 20230603_61687_61697_1 intersects
part 20230603_61690_61695_1 (state Active) It is a bug.
(LOGICAL_ERROR)`. This was using v22.12 (this commit I think: https://github.com/ClickHouse/ClickHouse/pull/44274/commits/10d87f90261194270bb05b64c66adf23aae65dc6). I can see that since then the
error message was adjusted, but I don't believe the bug itself has been
resolved.

I believe the bug comes from this change (https://github.com/jawm/ClickHouse/commit/c976b28104265dc03041bd8a3755de3f1c729794).
It's associated with this pull request: (https://github.com/ClickHouse/ClickHouse/pull/41145).
Specifically changes to the file `src/Storages/MergeTree/MergeTreeData.cpp`
seem maybe incorrect to me, since the logic used when a part is covered
by another part seems to have changed as described below.

The change modifies the function `renameTempPartAndReplaceImpl`, such
that a call to `getPartHierarchy` is used where previously there was a
call to `getActivePartsToReplace`. These two functions have a similar
implementation, but one notable difference -- in the latter, execution
breaks early if a covering part is found over the new part. In `renameTempPartAndReplaceImpl`, there was a condition looking for this covering part, which if
hit, would print the warning and return false.

Without the check, it instead continues, sees that there is an
intersecting part, and crashed with the exception. I believe that the
"intersecting" part would also be considered a "covering" part, as in
this case it covers the block range from before -> after the range of
the new part.

I believe a solution is to simply re-add the condition which checks for
a covering part, and return early in that case. However, my assessment
could be very wrong, I can't say I understand this code all that well. I
also don't really know how I could write a test for this either.

The other relevant detail; This occurred at the moment when I was
running a mutation on a *different* partition of the table. It happened
on two occasions, so I'm pretty sure connected to the mutation, although
I don't know why operations in different partitions would affect each
other in this way.

---

I have a slightly-redacted stack trace (this is from v22.12):

```
2023-06-03T03:03:03.971 replicaX 2023.06.03 03:03:03.971515 [ 39 ] {} <Error> REDACTED::20230603_61687_61697_1 (MergeFromLogEntryTask): virtual bool DB::ReplicatedMergeMutateTaskBase::executeStep(): Code: 49. DB::Exception: Part 20230603_61687_61697_1 intersects part 20230603_61690_61695_1 (state Active) It is a bug. (LOGICAL_ERROR), Stack trace (when copying this message, always include the lines below):
2023-06-03T03:03:03.972 replicaX 0. ./obj-x86_64-linux-gnu/../contrib/llvm-project/libcxx/include/exception:134: Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, int) @ 0x149ca1f3 in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 1. ./obj-x86_64-linux-gnu/../src/Common/Exception.cpp:77: DB::Exception::Exception(DB::Exception::MessageMasked const&, int, bool) @ 0x98687ba in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 2. ./obj-x86_64-linux-gnu/../contrib/llvm-project/libcxx/include/string:1499: DB::Exception::Exception(int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) @ 0x986f14c in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 3. ./obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeTreeData.cpp:0: DB::MergeTreeData::renameTempPartAndReplaceImpl(std::__1::shared_ptr<DB::IMergeTreeDataPart>&, DB::MergeTreeData::Transaction&, std::__1::unique_lock<std::__1::mutex>&, std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const>>>*) @ 0x13c8377c in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 4. ./obj-x86_64-linux-gnu/../contrib/llvm-project/libcxx/include/__mutex_base:144: DB::MergeTreeData::renameTempPartAndReplace(std::__1::shared_ptr<DB::IMergeTreeDataPart>&, DB::MergeTreeData::Transaction&) @ 0x13c83a2a in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 5. ./obj-x86_64-linux-gnu/../contrib/llvm-project/libcxx/include/vector:537: DB::MergeTreeDataMergerMutator::renameMergedTemporaryPart(std::__1::shared_ptr<DB::IMergeTreeDataPart>&, std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const>>> const&, std::__1::shared_ptr<DB::MergeTreeTransaction> const&, DB::MergeTreeData::Transaction&) @ 0x13cdb3a5 in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 6. ./obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeFromLogEntryTask.cpp:0: DB::MergeFromLogEntryTask::finalize(std::__1::function<void (DB::ExecutionStatus const&)>) @ 0x13c3c597 in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 7. ./obj-x86_64-linux-gnu/../src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.cpp:0: DB::ReplicatedMergeMutateTaskBase::executeImpl() @ 0x13e0f254 in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 8. ./obj-x86_64-linux-gnu/../src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.cpp:0: DB::ReplicatedMergeMutateTaskBase::executeStep() @ 0x13e0e5c2 in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 9. ./obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp:137: DB::MergeTreeBackgroundExecutor<DB::MergeMutateRuntimeQueue>::routine(std::__1::shared_ptr<DB::TaskRuntimeData>) @ 0x13c565db in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 10. ./obj-x86_64-linux-gnu/../contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::MergeTreeBackgroundExecutor<DB::MergeMutateRuntimeQueue>::threadFunction() @ 0x13c57385 in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 11. ./obj-x86_64-linux-gnu/../base/base/../base/wide_integer_impl.h:786: ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::worker(std::__1::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>) @ 0x98faa79 in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 12. ./obj-x86_64-linux-gnu/../src/Common/ThreadPool.cpp:0: ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'()::operator()() @ 0x98fd3dc in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 13. ./obj-x86_64-linux-gnu/../base/base/../base/wide_integer_impl.h:786: ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x98f8dd9 in /usr/bin/clickhouse
2023-06-03T03:03:03.972 replicaX 14. ./obj-x86_64-linux-gnu/../contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: void* std::__1::__thread_proxy[abi:v15000]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x98fbb8e in /usr/bin/clickhouse
2023-06-03T03:03:03.973 replicaX 15. start_thread @ 0x7fa3 in /lib/x86_64-linux-gnu/libpthread-2.28.so
2023-06-03T03:03:03.973 replicaX 16. __clone @ 0xf94cf in /lib/x86_64-linux-gnu/libc-2.28.so
2023-06-03T03:03:03.973 replicaX  (version 22.12.1.1-testing-1056-gbc8e9d688792)
```


<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix a rare bug which would cause server to crash after finding "intersecting" parts.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
